### PR TITLE
Update nginx-http for changes to base-image-openresty.

### DIFF
--- a/docker/usr/local/openresty/nginx/conf.d/nginx-httpd.conf
+++ b/docker/usr/local/openresty/nginx/conf.d/nginx-httpd.conf
@@ -61,6 +61,10 @@ server {
     listen 80;
     server_name familylife.com storyrunners.org;
 
+    set_by_lua $environment 'return os.getenv("ENVIRONMENT") or "development"';
+    access_log syslog:server=unix:/var/log/nginx/access.sock;
+    access_log /var/log/nginx/access.log json_combined;
+
     # Endpoint used for performing domain verification with Let's Encrypt.
     location ^~ /.well-known/acme-challenge/ {
         content_by_lua_block {
@@ -76,6 +80,10 @@ server {
 # HTTP
 server {
     listen 80 default_server;
+
+    set_by_lua $environment 'return os.getenv("ENVIRONMENT") or "development"';
+    access_log syslog:server=unix:/var/log/nginx/access.sock;
+    access_log /var/log/nginx/access.log json_combined;
 
     # Endpoint used for performing domain verification with Let's Encrypt.
     location ^~ /.well-known/acme-challenge/ {


### PR DESCRIPTION
Base image uses an $environment variable which wasn't present the lat time this was built 2 years ago.